### PR TITLE
Implement Unread Counter

### DIFF
--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -1,8 +1,9 @@
-import React from "react";
-import { makeStyles } from "@material-ui/core/styles";
+import { Header, Input, Messages } from "./index";
+
 import { Box } from "@material-ui/core";
-import { Input, Header, Messages } from "./index";
+import React from "react";
 import { connect } from "react-redux";
+import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles(() => ({
   root: {

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -1,10 +1,17 @@
-import React from "react";
+import { OtherUserBubble, SenderBubble } from "../ActiveChat";
+import React, { useEffect } from "react";
+
 import { Box } from "@material-ui/core";
-import { SenderBubble, OtherUserBubble } from "../ActiveChat";
+import { connect } from "react-redux";
 import moment from "moment";
+import { readMessage } from "../../store/utils/thunkCreators";
 
 const Messages = (props) => {
-  const { messages, otherUser, userId } = props;
+  const { messages, otherUser, userId, readMessage } = props;
+
+  useEffect(() => {
+    readMessage(messages[messages.length - 1]);
+  }, [messages, readMessage]);
 
   return (
     <Box>
@@ -21,4 +28,12 @@ const Messages = (props) => {
   );
 };
 
-export default Messages;
+const mapDispatchToProps = (dispatch) => {
+  return {
+    readMessage: (message) => {
+      dispatch(readMessage(message));
+    },
+  };
+};
+
+export default connect(undefined, mapDispatchToProps)(Messages);

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -1,11 +1,12 @@
-import React, { Component } from "react";
-import { Box } from "@material-ui/core";
 import { BadgeAvatar, ChatContent } from "../Sidebar";
-import { withStyles } from "@material-ui/core/styles";
-import { setActiveChat } from "../../store/activeConversation";
-import { connect } from "react-redux";
+import React, { Component } from "react";
 
-const styles = {
+import { Box } from "@material-ui/core";
+import { connect } from "react-redux";
+import { setActiveChat } from "../../store/activeConversation";
+import { withStyles } from "@material-ui/core/styles";
+
+const styles = (theme) => ({
   root: {
     borderRadius: 8,
     height: 80,
@@ -17,16 +18,35 @@ const styles = {
       cursor: "grab",
     },
   },
-};
+  unreadCounter: {
+    borderRadius: 10,
+    height: 20,
+    padding: "0 0.5em",
+    background: theme.palette.primary.main,
+    color: theme.palette.common.white,
+    fontWeight: "bold",
+    textAlign: "center",
+  }
+});
 
 class Chat extends Component {
   handleClick = async (conversation) => {
     await this.props.setActiveChat(conversation.otherUser.username);
   };
 
+  calculateUnreadCount() {
+    const { messages, lastReadMessageId } = this.props.conversation;
+    if (lastReadMessageId) {
+      return messages.length - messages.findIndex((message) => message.id === lastReadMessageId) - 1;
+    }
+    return messages.length;
+  }
+
   render() {
     const { classes } = this.props;
     const otherUser = this.props.conversation.otherUser;
+    const unreadCount = this.calculateUnreadCount();
+
     return (
       <Box
         onClick={() => this.handleClick(this.props.conversation)}
@@ -39,6 +59,12 @@ class Chat extends Component {
           sidebar={true}
         />
         <ChatContent conversation={this.props.conversation} />
+        {
+          unreadCount !== 0 &&
+          <Box className={classes.unreadCounter}>
+            {unreadCount}
+          </Box>
+        }
       </Box>
     );
   }

--- a/client/src/store/conversations.js
+++ b/client/src/store/conversations.js
@@ -1,9 +1,10 @@
 import {
+  addLastReadMessage,
+  addMessageToStore,
   addNewConvoToStore,
   addOnlineUserToStore,
   addSearchedUsersToStore,
   removeOfflineUserFromStore,
-  addMessageToStore,
 } from "./utils/reducerFunctions";
 
 // ACTIONS
@@ -15,6 +16,7 @@ const REMOVE_OFFLINE_USER = "REMOVE_OFFLINE_USER";
 const SET_SEARCHED_USERS = "SET_SEARCHED_USERS";
 const CLEAR_SEARCHED_USERS = "CLEAR_SEARCHED_USERS";
 const ADD_CONVERSATION = "ADD_CONVERSATION";
+const SET_READ_MESSAGE = "READ_MESSAGE";
 
 // ACTION CREATORS
 
@@ -67,6 +69,13 @@ export const addConversation = (recipientId, newMessage) => {
   };
 };
 
+export const setReadMessage = (message) => {
+  return {
+    type: SET_READ_MESSAGE,
+    payload: { message },
+  };
+};
+
 // REDUCER
 
 const reducer = (state = [], action) => {
@@ -91,6 +100,8 @@ const reducer = (state = [], action) => {
         action.payload.recipientId,
         action.payload.newMessage
       );
+    case SET_READ_MESSAGE:
+      return addLastReadMessage(state, action.payload.message);
     default:
       return state;
   }

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -14,7 +14,7 @@ export const addMessageToStore = (state, payload) => {
   return state.map((convo) => {
     if (convo.id === message.conversationId) {
       const convoCopy = { ...convo };
-      convoCopy.messages.push(message);
+      convoCopy.messages = [...convo.messages, message];
       convoCopy.latestMessageText = message.text;
 
       return convoCopy;
@@ -73,9 +73,21 @@ export const addNewConvoToStore = (state, recipientId, message) => {
     if (convo.otherUser.id === recipientId) {
       const newConvo = { ...convo };
       newConvo.id = message.conversationId;
-      newConvo.messages.push(message);
+      newConvo.messages = [...convo.messages, message];
       newConvo.latestMessageText = message.text;
       return newConvo;
+    } else {
+      return convo;
+    }
+  });
+};
+
+export const addLastReadMessage = (state, message) => {
+  return state.map((convo) => {
+    if (convo.id === message.conversationId) {
+      const convoCopy = { ...convo };
+      convoCopy.lastReadMessageId = message.id;
+      return convoCopy;
     } else {
       return convo;
     }

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -2,6 +2,7 @@ import {
   addConversation,
   gotConversations,
   setNewMessage,
+  setReadMessage,
   setSearchedUsers,
 } from "../conversations";
 import { gotUser, setFetchingStatus } from "../user";
@@ -108,3 +109,12 @@ export const searchUsers = (searchTerm) => async (dispatch) => {
     console.error(error);
   }
 };
+
+export const readMessage = (message) => async (dispatch) => {
+  try {
+    await axios.post('/api/messages/read', { messageId: message.id });
+    dispatch(setReadMessage(message));
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -7,8 +7,13 @@ const Message = require("./message");
 User.hasMany(Conversation);
 Conversation.belongsTo(User, { as: "user1" });
 Conversation.belongsTo(User, { as: "user2" });
+
 Message.belongsTo(Conversation);
 Conversation.hasMany(Message);
+
+Conversation.belongsTo(Message, { as: "user1lastread", constraints: false });
+Conversation.belongsTo(Message, { as: "user2lastread", constraints: false });
+Message.hasMany(Conversation, { constraints: false });
 
 module.exports = {
   User,

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -69,14 +69,19 @@ router.get("/", async (req, res, next) => {
       const convo = conversations[i];
       const convoJSON = convo.toJSON();
 
-      // set a property "otherUser" so that frontend will have easier access
+      // set a property "otherUser" and "lastReadMessageId"
+      // so that frontend will have easier access
       if (convoJSON.user1) {
         convoJSON.otherUser = convoJSON.user1;
+        convoJSON.lastReadMessageId = convoJSON.user2lastreadId;
         delete convoJSON.user1;
       } else if (convoJSON.user2) {
         convoJSON.otherUser = convoJSON.user2;
+        convoJSON.lastReadMessageId = convoJSON.user1lastreadId;
         delete convoJSON.user2;
       }
+      delete convoJSON.user1lastreadId;
+      delete convoJSON.user2lastreadId;
 
       // set property for online status of the other user
       if (onlineUsers.has(convoJSON.otherUser.id)) {

--- a/server/routes/api/messages.js
+++ b/server/routes/api/messages.js
@@ -48,4 +48,32 @@ router.post("/", async (req, res, next) => {
   }
 });
 
+// expects { messageId } in body.
+router.post("/read", async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res.sendStatus(401);
+    }
+    const { messageId } = req.body;
+
+    const message = await Message.findByPk(messageId);
+    const conversation = await message.getConversation();
+
+    if (conversation.user1Id === req.user.id) {
+      conversation.setUser1lastread(message);
+      conversation.save();
+    } else if (conversation.user2Id === req.user.id) {
+      conversation.setUser2lastread(message);
+      conversation.save();
+    } else {
+      // Unauthorized.
+      return res.sendStatus(401);
+    }
+
+    res.json(true);
+  } catch (error) {
+    next(error);
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
Resolve #5 

# Changes
## Server
- Add `user1lastread` and `user2lastread` field to `conversations` table.
- Add `lastReadMessageId` property to each conversation in `GET /api/conversations` response.
- Add `POST /api/messages/read` endpoint.
- Add unread counter UI component.

## Client
- Add `SET_READ_MESSAGE` action.
- `SET_READ_MESSAGE` action is dispatched whenever `Messages` component gets rendered with different `messages` props.

## Screenshots
![image](https://user-images.githubusercontent.com/8978815/119312048-d7896780-bc3f-11eb-9e0f-f20deeb03b6d.png)
